### PR TITLE
Fix: Rename references after move to ergebnis

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DOCKER_IMAGE: localheinz/github-action-template
+      DOCKER_IMAGE: ergebnis/github-action-template
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DOCKER_IMAGE: localheinz/github-action-template
+      DOCKER_IMAGE: ergebnis/github-action-template
 
     steps:
       - name: "Checkout"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`34c52fe...master`](https://github.com/localheinz/github-action-template/compare/34c52fe...master).
+For a full diff see [`34c52fe...master`](https://github.com/ergebnis/github-action-template/compare/34c52fe...master).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3-cli-alpine
 
-LABEL "repository"="https://github.com/localheinz/github-action-template"
-LABEL "homepage"="https://github.com/localheinz/github-action-template"
+LABEL "repository"="https://github.com/ergebnis/github-action-template"
+LABEL "homepage"="https://github.com/ergebnis/github-action-template"
 LABEL "maintainer"="Andreas Möller <am@localheinz.com>"
 
 ADD entrypoint.sh /entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docker help it
 
-DOCKER_IMAGE:=localheinz/github-action-template
+DOCKER_IMAGE:=ergebnis/github-action-template
 
 it: docker ## Runs the docker target
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # github-action-template
 
-[![Continuous Integration](https://github.com/localheinz/github-action-template/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/github-action-template/actions)
-[![Continuous Deployment](https://github.com/localheinz/github-action-template/workflows/Continuous%20Deployment/badge.svg)](https://github.com/localheinz/github-action-template/actions)
+[![Continuous Integration](https://github.com/ergebnis/github-action-template/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/github-action-template/actions)
+[![Continuous Deployment](https://github.com/ergebnis/github-action-template/workflows/Continuous%20Deployment/badge.svg)](https://github.com/ergebnis/github-action-template/actions)
 
 ## What does this action do?
 
@@ -27,15 +27,15 @@ name: "Continuous Integration"
 jobs:
   github-action-template:
     name: github-action-template
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@master
 
       - name: "Run action"
-        uses: docker://localheinz/github-action-template:latest
+        uses: docker://ergebnis/github-action-template:latest
 ```
 
 ### Docker image
@@ -45,12 +45,12 @@ As Docker images are automatically built and pushed on a merge to `master` or wh
 :bulb: The Docker image can also be executed directly by running
 
 ```
-$ docker run --interactive --rm --tty --workdir=/app --volume ${PWD}:/app localheinz/github-action-template:latest
+$ docker run --interactive --rm --tty --workdir=/app --volume ${PWD}:/app ergebnis/github-action-template:latest
 ```
 
 For more information, see the [Docker Docs: Docker run reference](https://docs.docker.com/engine/reference/run/).
 
-Instead of using the latest pre-built Docker image, you can also specify a Docker image tag (which corresponds to the tags [released on GitHub](https://github.com/localheinz/github-action-template/releases)):
+Instead of using the latest pre-built Docker image, you can also specify a Docker image tag (which corresponds to the tags [released on GitHub](https://github.com/ergebnis/github-action-template/releases)):
 
 ```diff
  on:
@@ -66,16 +66,16 @@ Instead of using the latest pre-built Docker image, you can also specify a Docke
  jobs:
    github-action-template:
      name: github-action-template
-    
+
      runs-on: ubuntu-latest
-    
+
      steps:
        - name: "Checkout"
          uses: actions/checkout@master
 
        - name: "Run action"
--        uses: docker://localheinz/github-action-template:latest
-+        uses: docker://localheinz/github-action-template:1.2.3
+-        uses: docker://ergebnis/github-action-template:latest
++        uses: docker://ergebnis/github-action-template:1.2.3
 ```
 
 ## Changelog

--- a/action.yml
+++ b/action.yml
@@ -12,4 +12,4 @@ author: 'localheinz'
 
 runs:
   using: 'docker'
-  image: 'docker://localheinz/github-action-template'
+  image: 'docker://ergebnis/github-action-template'


### PR DESCRIPTION
This PR

* [x] renames references after the move from @localheinz to @ergebnis