### PR TITLE
Enhancement: Use PHP 7.4 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 LABEL "repository"="https://github.com/ergebnis/github-action-template"
 LABEL "homepage"="https://github.com/ergebnis/github-action-template"


### PR DESCRIPTION
This PR

* [x] uses `php:7.4-cli-alpine` instead of `php:7.3-cli-alpine` as base Docker image