### PR TITLE
Fix: Run continuous-integration.yml workflow on pull request only

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,11 +2,6 @@
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
-    tags:
-      - "**"
 
 name: "Continuous Integration"
 


### PR DESCRIPTION
This PR

* [x] runs the `continuous-integration.yml` on pull request only